### PR TITLE
IL Statewide

### DIFF
--- a/lib/states/il/statewide.R
+++ b/lib/states/il/statewide.R
@@ -50,6 +50,9 @@ clean <- function(d, helpers) {
     rename(
       location = ZIP,
       beat = BeatLocationOfStop,
+      # TODO(walterk): Determine whether Chicago should be removed from this
+      # dataset.
+      # https://app.asana.com/0/456927885748233/727769678078651
       department_name = AgencyName,
       department_id = AgencyCode,
       vehicle_make = VehicleMake,
@@ -93,7 +96,9 @@ clean <- function(d, helpers) {
       search_vehicle = VehicleSearchConducted == 1
         | PoliceDogVehicleSearched == 1,
       search_conducted = search_person | search_vehicle,
-      # TODO(wkim): Confirm with Ravi that "k9" is prioritized before "consent".
+      # TODO(walterk): Resolve the priority of "k9" vs "consent" for
+      # "search_type".
+      # https://app.asana.com/0/456927885748233/727766038302995
       search_type = if_else(
         PoliceDogAlertIfSniffed == 1,
         "k9",


### PR DESCRIPTION
This commit loads and cleans the IL statewide data.  

The original raw data has two folder, `local` and `statewide`.  This only loads the 2012 - 2016 (5 years) of data from the `statewide` folder.  The raw data filenames are of the form `<YEAR> ITSS Data.txt`.

This data includes `AgencyName == CHICAGO POLICE` and other city level jurisdictions.  At the very least, we should filter out Chicago given that we have separate Chicago data, and possibly other cities as we receive data for other IL cities.

Some of the data cleaning choices were made to reflect the work done here: https://github.com/5harad/openpolicing/blob/master/src/processing/states/IL.R

Should I be doing a `select` in the `clean` function to remove all the columns from the raw data that have "cleaned" counterparts?
