### PR TITLE
Added temporary fix for download script error

### DIFF
--- a/py/download.py
+++ b/py/download.py
@@ -80,7 +80,11 @@ def to_regular_dict(dd):
 
 
 def info(url):
-    state, city = resolve_location(url)
+    terms = resolve_location(url)
+    # Temporary fix for resolve_location ValueError
+    if len(terms) != 2:
+        return "NA", "NA", resolve_file_type(url)
+    state, city = terms
     file_type = resolve_file_type(url)
     return state, city, file_type
 


### PR DESCRIPTION
Data downloaders do not work because the URL contains files that do not follow the state_city format. This causes the parser to fail.

### Error
<img width="1168" alt="Screenshot 2023-05-14 at 1 50 34 PM" src="https://github.com/stanford-policylab/opp/assets/74080246/9e9ba56a-0a81-47da-8662-66b81b1592fc">

### Fix
This temporary workaround ignores URLs that do not follow the format. This fixes the issue and allows the download script to run as intended. 